### PR TITLE
Build using Jython 2.7-b1

### DIFF
--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-jython-shaded</artifactId>
-		<version>2.5.4-SNAPSHOT</version>
+		<version>2.7-b1</version>
 	</parent>
 
 	<artifactId>jython-deps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>pom-jython-shaded</artifactId>
-	<version>2.5.4-SNAPSHOT</version>
+	<version>2.7-b1</version>
 	<packaging>pom</packaging>
 
 	<description>Jython is an implementation of the high-level, dynamic, object-oriented language Python written in 100% Pure Java, and seamlessly integrated with the Java platform. It thus allows you to run Python on any Java platform.</description>
@@ -49,7 +49,7 @@
 	</scm>
 
 	<properties>
-		<jython.version>2.5.3</jython.version>
+		<jython.version>2.7-b1</jython.version>
 	</properties>
 
 	<build>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-jython-shaded</artifactId>
-		<version>2.5.4-SNAPSHOT</version>
+		<version>2.7-b1</version>
 	</parent>
 
 	<artifactId>jython-shaded</artifactId>


### PR DESCRIPTION
As Jython 2.7-b3 requires Java 7 this is required to have Jython 2.7 in combination with the Fiji default Java.
