### PR TITLE
Update to jython 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides a rebundled version of the Jython library with shaded
 <dependency>
 	<groupId>org.scijava</groupId>
 	<artifactId>jython-shaded</artifactId>
-	<version>2.5.3</version>
+	<version>2.7.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -30,7 +30,7 @@ The naive way to add a Jython dependency is:
 <dependency>
 	<groupId>org.python</groupId>
 	<artifactId>jython</artifactId>
-	<version>2.5.3</version>
+	<version>2.7.0</version>
 </dependency>
 ```
 
@@ -43,7 +43,7 @@ So another artifact is available which includes those libraries:
 <dependency>
 	<groupId>org.python</groupId>
 	<artifactId>jython-standalone</artifactId>
-	<version>2.5.3</version>
+	<version>2.7.0</version>
 </dependency>
 ```
 
@@ -56,8 +56,10 @@ luck.
 
 ### Example
 
+**!!! This example needs to be updated for jython 2.7.0 !!!**
+
 Here is an example Jython script that produces an exception when attempting to
-run it using Jython 2.5.3 when JRuby 1.7.12 and dependencies (including JFFI
+run it using Jython 2.7.0 when JRuby 1.7.12 and dependencies (including JFFI
 1.2.7) are also on the classpath:
 
 ```
@@ -69,8 +71,8 @@ The exception which occurs is:
 ```
 Traceback (most recent call last):
 	File "test.py", line 2, in <module>
-	File ".../jython-standalone-2.5.3.jar/Lib/posixpath.py", line 195, in isdir
-	File ".../jython-standalone-2.5.3.jar/Lib/posixpath.py", line 195, in isdir
+	File ".../jython-standalone-2.7.0.jar/Lib/posixpath.py", line 195, in isdir
+	File ".../jython-standalone-2.7.0.jar/Lib/posixpath.py", line 195, in isdir
 java.lang.IncompatibleClassChangeError: Found class com.kenai.jffi.InvocationBuffer, but interface was expected
 	at com.kenai.jaffl.provider.jffi.AsmRuntime.marshal(AsmRuntime.java:167)
 	at org.python.posix.LibC$jaffl$0.stat$raw(Unknown Source)
@@ -79,8 +81,8 @@ java.lang.IncompatibleClassChangeError: Found class com.kenai.jffi.InvocationBuf
 	at org.python.posix.LazyPOSIX.stat(LazyPOSIX.java:207)
 	at org.python.modules.posix.PosixModule$StatFunction.__call__(PosixModule.java:954)
 	at org.python.core.PyObject.__call__(PyObject.java:391)
-	at posixpath$py.isdir$17(/Applications/Science/Fiji.app/jars/jython-standalone-2.5.3.jar/Lib/posixpath.py:198)
-	at posixpath$py.call_function(/Applications/Science/Fiji.app/jars/jython-standalone-2.5.3.jar/Lib/posixpath.py)
+	at posixpath$py.isdir$17(/Applications/Science/Fiji.app/jars/jython-standalone-2.7.0.jar/Lib/posixpath.py:198)
+	at posixpath$py.call_function(/Applications/Science/Fiji.app/jars/jython-standalone-2.7.0.jar/Lib/posixpath.py)
 	at org.python.core.PyTableCode.call(PyTableCode.java:165)
 	at org.python.core.PyBaseCode.call(PyBaseCode.java:134)
 	at org.python.core.PyFunction.__call__(PyFunction.java:317)

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -35,13 +36,12 @@
 				</configuration>
 			</plugin>
 
-			<!-- NB: Shade all of Jython's dependencies, excluding Jython's <foo>.py
-			     classes, because they cause problems with ASM processing. This is
-			     OK, because they are wrappers which do not directly reference the
-			     dependencies, and hence do not require bytecode modification. The
-			     resultant artifact will then be consumed by the next module in the
-			     build (org.scijava:jython-shaded) which will readd the <foo>.py
-			     classes unaltered. -->
+			<!-- NB: Shade all of Jython's dependencies, excluding Jython's <foo>.py 
+				classes, because they cause problems with ASM processing. This is OK, because 
+				they are wrappers which do not directly reference the dependencies, and hence 
+				do not require bytecode modification. The resultant artifact will then be 
+				consumed by the next module in the build (org.scijava:jython-shaded) which 
+				will readd the <foo>.py classes unaltered. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
@@ -52,6 +52,8 @@
 							<artifact>org.python:jython-standalone</artifact>
 							<excludes>
 								<exclude>**/*$py.class</exclude>
+								<exclude>org/w3c/dom/**</exclude>
+								<exclude>org/xml/sax/**</exclude>
 							</excludes>
 						</filter>
 					</filters>
@@ -59,12 +61,41 @@
 						<relocation>
 							<pattern></pattern>
 							<shadedPattern>org.scijava.jython.shaded.</shadedPattern>
-							<excludes>
-								<exclude>org/python/**</exclude>
-								<exclude>Lib/**</exclude>
-								<exclude>license/**</exclude>
-								<exclude>META-INF/**</exclude>
-							</excludes>
+							<includes>
+								<include>ProxyDeserialization</include>
+							</includes>
+						</relocation>
+						<relocation>
+							<pattern>com.kenai</pattern>
+							<shadedPattern>org.scijava.jython.shaded.com.kenai</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>com.xhaus</pattern>
+							<shadedPattern>org.scijava.jython.shaded.com.xhaus</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>com.ziclix</pattern>
+							<shadedPattern>org.scijava.jython.shaded.com.ziclix</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>javatests</pattern>
+							<shadedPattern>org.scijava.jython.shaded.javatests</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>javax.xml</pattern>
+							<shadedPattern>org.scijava.jython.shaded.javax.xml</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>jline</pattern>
+							<shadedPattern>org.scijava.jython.shaded.jline</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>jnr</pattern>
+							<shadedPattern>org.scijava.jython.shaded.jnr</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>org.fusesource</pattern>
+							<shadedPattern>org.scijava.jython.shaded.org.fusesource</shadedPattern>
 						</relocation>
 					</relocations>
 				</configuration>

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-jython-shaded</artifactId>
-		<version>2.5.4-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jython-deps</artifactId>
@@ -43,7 +43,9 @@
 			     build (org.scijava:jython-shaded) which will readd the <foo>.py
 			     classes unaltered. -->
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.3</version>
 				<configuration>
 					<filters>
 						<filter>
@@ -55,40 +57,14 @@
 					</filters>
 					<relocations>
 						<relocation>
-							<pattern>com.google</pattern>
-							<shadedPattern>org.scijava.jython.shaded.com.google</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>com.kenai</pattern>
-							<shadedPattern>org.scijava.jython.shaded.com.kenai</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>com.xhaus</pattern>
-							<shadedPattern>org.scijava.jython.shaded.com.xhaus</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>com.ziclix</pattern>
-							<shadedPattern>org.scijava.jython.shaded.com.ziclix</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>javatests</pattern>
-							<shadedPattern>org.scijava.jython.shaded.javatests</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>jline</pattern>
-							<shadedPattern>org.scijava.jython.shaded.jline</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>jni</pattern>
-							<shadedPattern>org.scijava.jython.shaded.jni</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>jnr</pattern>
-							<shadedPattern>org.scijava.jython.shaded.jnr</shadedPattern>
-						</relocation>
-						<relocation>
-							<pattern>org.w3c</pattern>
-							<shadedPattern>org.scijava.jython.shaded.org.w3c</shadedPattern>
+							<pattern></pattern>
+							<shadedPattern>org.scijava.jython.shaded.</shadedPattern>
+							<excludes>
+								<exclude>org/python/**</exclude>
+								<exclude>Lib/**</exclude>
+								<exclude>license/**</exclude>
+								<exclude>META-INF/**</exclude>
+							</excludes>
 						</relocation>
 					</relocations>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>pom-jython-shaded</artifactId>
-	<version>2.5.4-SNAPSHOT</version>
+	<version>2.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Jython is an implementation of the high-level, dynamic, object-oriented language Python written in 100% Pure Java, and seamlessly integrated with the Java platform. It thus allows you to run Python on any Java platform.</description>
@@ -49,7 +49,7 @@
 	</scm>
 
 	<properties>
-		<jython.version>2.5.3</jython.version>
+		<jython.version>2.7.0</jython.version>
 	</properties>
 
 	<build>

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-jython-shaded</artifactId>
-		<version>2.5.4-SNAPSHOT</version>
+		<version>2.7.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jython-shaded</artifactId>


### PR DESCRIPTION
An update to jython-shaded that uses jython version 2.7.0.  Currently jython-shaded versioned at 2.7.0-SNAPSHOT so you can look it over.  Probably needs some testing.